### PR TITLE
Fix for dropdown menu items not working

### DIFF
--- a/_sass/_home.scss
+++ b/_sass/_home.scss
@@ -309,12 +309,6 @@
             outline: none;
           }
 
-          @media screen and (max-width: 767px) {
-            .slick-next.slick-arrow {
-              display: none !important;
-            }
-          }
-
           // .slick-dots li button:before {
           //   font-size: 0.5rem !important;
           //   color: $white !important;
@@ -1002,6 +996,14 @@ section.home-use-case-blade {
     margin: 0 auto;
   }
 }
+
+/* Fix for horizontal scrolling caused by right arrow on both sliders */
+@media screen and (max-width: 767px) {
+  .slick-next.slick-arrow {
+    display: none !important;
+  }
+}
+
 /* Fade In Blurb*/
 .fadeInSlideTxt {
   max-width: 180px;


### PR DESCRIPTION
<!--- Provide a general summary of your changes in the Title above -->

## Description

The menu parent was getting the event and then called preventDefault() so clicks on links were not going anywhere. Added a click listener on the submenu links that simply calls preventPropagation() on the event to stop bubbling and naturally let the browser follow the link.

## Related Issue

<!--- This project only accepts pull requests related to open issues -->
<!--- If suggesting a new feature or change, please discuss it in an issue first -->
<!--- If fixing a bug, there should be an issue describing it with steps to reproduce -->
<!--- Please link to the issue here: -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

## How Has This Been Tested?

Functional testing in Chrome.

## Screenshots (if appropriate):

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

- [x] I have signed the [Adobe Open Source CLA](https://opensource.adobe.com/cla.html).
- [x] My code follows the code style of this project.
- [ ] My change requires a change to the documentation.
- [ ] I have updated the documentation accordingly.
- [x] I have read the **CONTRIBUTING** document.
- [ ] I have added tests to cover my changes.
- [ ] All new and existing tests passed.
